### PR TITLE
Update setbiblio.html: Logique et Analyse, Fixing Frege’s Set Theory, flash-sheridan.name

### DIFF
--- a/Bibliography/setbiblio.html
+++ b/Bibliography/setbiblio.html
@@ -2006,7 +2006,12 @@ Quart., <B>63</B>, Issue 5, p. 342--363, 2017
 	at <a href="http://www-logic.stanford.edu/seminar/1314/Sheridan_Fixing_Freges_Set_Theory.pdf">
 	http://www-logic.stanford.edu/seminar/1314/Sheridan_Fixing_Freges_Set_Theory.pdf </a>.</P>
 
-	
+	<LI><P STYLE="margin-bottom: 0in"><STRONG>Sheridan, Flash [2024]
+	<BR></STRONG><CITE>A Closer Look at the Russell Paradox.</CITE> 
+	<BR>To appear in Logique et Analyse.  Preprint at <a href="https://arxiv.org/abs/2103.00090">https://arxiv.org/abs/2103.00090</a>.
+	  </P>
+
+
 	<LI><P STYLE="margin-bottom: 0in"><STRONG>Skala, H. [1974a] <BR></STRONG><CITE>Eine
 	neue Methode, die Paradoxien der na&iuml;ven Mengenlehre zu
 	vermeiden.</CITE> <BR>Annalen der &Ouml;sterreichen Akademie der

--- a/Bibliography/setbiblio.html
+++ b/Bibliography/setbiblio.html
@@ -1991,21 +1991,20 @@ Quart., <B>63</B>, Issue 5, p. 342--363, 2017
 	this modified iterative conception of set supports the axioms of
 	Quine's set theory NF.'')</P>
 
-		<LI><P STYLE="margin-bottom: 0in"><STRONG>Sheridan, Flash [2014]
+		<LI><P STYLE="margin-bottom: 0in"><STRONG>Sheridan, Flash [2016]
 	<BR></STRONG><CITE>A Variant of Church's Set Theory with a Universal
 		      Set in which the Singleton Function is a Set.</CITE> <BR>
 
 		    <a href ="http://virthost.vub.ac.be/lnaweb/ojs/index.php/LogiqueEtAnalyse/article/view/1903">
 		      Logique et Analyse <B>59</B> (233) pp. 81-131, doi:10.2143/LEA.233.0.3149532</a>
  <BR>This is an abridged version of an Oxford doctoral thesis awaiting resubmission. The
- full version is online at <a href=" http://www.logic-center.be/Publications/Bibliotheque/SheridanVariantChurch.pdf"> 
- http://www.logic-center.be/Publications/Bibliotheque/SheridanVariantChurch.pdf.</a>
+ full version is online at <a href="http://www.logic-center.be/assets/pdf/SheridanVariantChurch.pdf"> 
+ http://www.logic-center.be/assets/pdf/SheridanVariantChurch.pdf.</a>
  <BR>
    <ahref="http://www.logic-center.be/Publications/Bibliotheque/SheridanVariantChurch.pdf">
 	Slides for a talk summarizing the results and philosophy are
-	at <a href="http://pobox.com/~flash/Fixing_Freges_Set_Theory.pdf">
-	http://pobox.com/~flash/Fixing_Freges_Set_Theory.pdf </a>.</P>
-		  <http://virthost.vub.ac.be/lnaweb/ojs/index.php/LogiqueEtAnalyse/article/view/1903>
+	at <a href="http://www-logic.stanford.edu/seminar/1314/Sheridan_Fixing_Freges_Set_Theory.pdf">
+	http://www-logic.stanford.edu/seminar/1314/Sheridan_Fixing_Freges_Set_Theory.pdf </a>.</P>
 
 	
 	<LI><P STYLE="margin-bottom: 0in"><STRONG>Skala, H. [1974a] <BR></STRONG><CITE>Eine

--- a/Bibliography/setbiblio.html
+++ b/Bibliography/setbiblio.html
@@ -1991,26 +1991,25 @@ Quart., <B>63</B>, Issue 5, p. 342--363, 2017
 	this modified iterative conception of set supports the axioms of
 	Quine's set theory NF.'')</P>
 
-		<LI><P STYLE="margin-bottom: 0in"><STRONG>Sheridan, Flash [2016]
+	<LI><P STYLE="margin-bottom: 0in"><STRONG>Sheridan, Flash [2016]
 	<BR></STRONG><CITE>A Variant of Church's Set Theory with a Universal
-		      Set in which the Singleton Function is a Set.</CITE> <BR>
-
-		    <a href ="http://virthost.vub.ac.be/lnaweb/ojs/index.php/LogiqueEtAnalyse/article/view/1903">
-		      Logique et Analyse <B>59</B> (233) pp. 81-131, doi:10.2143/LEA.233.0.3149532</a>
- <BR>This is an abridged version of an Oxford doctoral thesis awaiting resubmission. The
- full version is online at <a href="http://www.logic-center.be/assets/pdf/SheridanVariantChurch.pdf"> 
- http://www.logic-center.be/assets/pdf/SheridanVariantChurch.pdf.</a>
- <BR>
-   <ahref="http://www.logic-center.be/Publications/Bibliotheque/SheridanVariantChurch.pdf">
+	Set in which the Singleton Function is a Set.</CITE> <BR>
+	<a href ="http://virthost.vub.ac.be/lnaweb/ojs/index.php/LogiqueEtAnalyse/article/view/1903">
+	Logique et Analyse <B>59</B> (233) pp. 81-131, doi:10.2143/LEA.233.0.3149532</a>
+ 	<BR>This is an abridged version of an Oxford doctoral thesis awaiting resubmission. The
+ 	full version is online at <a href="http://www.logic-center.be/assets/pdf/SheridanVariantChurch.pdf"> 
+ 	http://www.logic-center.be/assets/pdf/SheridanVariantChurch.pdf.</a>
+ 	<BR>
+   	<a href="http://www.logic-center.be/Publications/Bibliotheque/SheridanVariantChurch.pdf">
 	Slides for a talk summarizing the results and philosophy are
 	at <a href="http://www-logic.stanford.edu/seminar/1314/Sheridan_Fixing_Freges_Set_Theory.pdf">
 	http://www-logic.stanford.edu/seminar/1314/Sheridan_Fixing_Freges_Set_Theory.pdf </a>.</P>
 
 	<LI><P STYLE="margin-bottom: 0in"><STRONG>Sheridan, Flash [2024]
 	<BR></STRONG><CITE>A Closer Look at the Russell Paradox.</CITE> 
-	<BR>To appear in Logique et Analyse.  Preprint at <a href="https://arxiv.org/abs/2103.00090">https://arxiv.org/abs/2103.00090</a>.
-	  </P>
-
+	<BR>To appear in Logique et Analyse.  Preprint at 
+	<a href="https://arxiv.org/abs/2103.00090">https://arxiv.org/abs/2103.00090</a>.
+	</P>
 
 	<LI><P STYLE="margin-bottom: 0in"><STRONG>Skala, H. [1974a] <BR></STRONG><CITE>Eine
 	neue Methode, die Paradoxien der na&iuml;ven Mengenlehre zu

--- a/nf.html
+++ b/nf.html
@@ -132,8 +132,8 @@ development and application of <A HREF = ../proverpage.html>the Watson
 theorem prover</A>, which uses a lambda-calculus equivalent to an
 extension of NFU as its higher order logic.  This descrption of my program is outdated:  look at my main page.<P>
 
-<A HREF = http://pobox.com/~flasheridn> Flash Sheridan</A> warns us
-that his page is mostly his Newton programming stuff.
+<A HREF = http://flash-sheridan.name> Flash Sheridan</A> warns us
+that his page is mostly his compiler testing, static analysis, and Newton programming stuff.
 
 <P>
 <A HREF = "http://www.math.psu.edu/jech/"> Thomas Jech </A> has worked on implementing the system of


### PR DESCRIPTION
* Change Fixing Frege’s Set Theory URL to Stanford.
* Update pobox.com/~flash[eridn] ⇒ flash-sheridan.name.  My supposed URL redirection service for life is dying in May.
* Update _Logique et Analyse_ URL and date for “A Variant of Church's Set Theory with a Universal Set in which the Singleton Function is a Set.”
* Add “A Closer Look at the Russell Paradox” (no _Logique et Analyse_ URL yet).
* Remove stray line.